### PR TITLE
Create sockets directoy if it does not exist.

### DIFF
--- a/lib/logjam/helpers.rb
+++ b/lib/logjam/helpers.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Logjam
   module Helpers
     def log_info(message)
@@ -18,6 +20,12 @@ module Logjam
 
     def extract_minute_from_iso8601(iso_string)
       60 * iso_string[11..12].to_i + iso_string[14..15].to_i
+    end
+
+    def socket_path
+      path = File.join(Rails.root, 'tmp', 'sockets')
+      FileUtils.mkdir_p(path) unless File.exists?(path)
+      path
     end
   end
 end

--- a/lib/logjam/request_processor_proxy.rb
+++ b/lib/logjam/request_processor_proxy.rb
@@ -38,7 +38,7 @@ module Logjam
     end
 
     def socket_file_name(pid)
-      "#{Rails.root}/tmp/sockets/state-#{@app}-#{@env}-#{pid}.ipc"
+      File.join(socket_path, "state-#{@app}-#{@env}-#{pid}.ipc")
     end
 
     def clean_old_sockets

--- a/lib/logjam/request_processor_server.rb
+++ b/lib/logjam/request_processor_server.rb
@@ -22,7 +22,7 @@ module Logjam
     end
 
     def socket_file_name
-      "#{Rails.root}/tmp/sockets/state-#{@stream.app}-#{@stream.env}-#{id}.ipc"
+      File.join(socket_path, "state-#{@stream.app}-#{@stream.env}-#{id}.ipc")
     end
 
     def setup_connection


### PR DESCRIPTION
Hi Stefan,

if you do not create the folder `tmp/sockets`, the IPC sockets cannot be created properly and LogJam is not able to process any requests. This commit fixes and and just creates the directory if it's missing.

Cheers,
plu
