### PR TITLE
Zmq error log

### DIFF
--- a/lib/logjam/request_processor_server.rb
+++ b/lib/logjam/request_processor_server.rb
@@ -33,7 +33,10 @@ module Logjam
         parts.each(&:close)
         on_reset_state_received
       end
-      @socket.bind("ipc:///#{socket_file_name}")
+      rc = @socket.bind("ipc:///#{socket_file_name}")
+      unless ZMQ::Util.resultcode_ok? rc
+        log_error("Could not bind to socket %s: %s (%d)" % [socket_file_name, ZMQ::Util.error_string, ZMQ::Util.errno])
+      end
     end
 
     def on_reset_state_received

--- a/lib/logjam/zmq_importer.rb
+++ b/lib/logjam/zmq_importer.rb
@@ -38,7 +38,10 @@ module Logjam
       @socket = @context.socket(ZMQ::PULL)
       @socket.setsockopt(ZMQ::LINGER, 500)
       @socket.setsockopt(ZMQ::RCVHWM, 5000)
-      @socket.bind("tcp://#{Logjam.bind_ip}:#{@port}")
+      rc = @socket.bind("tcp://#{Logjam.bind_ip}:#{@port}")
+      unless ZMQ::Util.resultcode_ok? rc
+        log_error("Could not bind to socket %s:%d: %s (%d)" % [Logjam.bind_ip, @port, ZMQ::Util.error_string, ZMQ::Util.errno])
+      end
       @socket.on(:message) do |p1, p2, p3|
         stream = p1.copy_out_string; p1.close
         key = p2.copy_out_string; p2.close


### PR DESCRIPTION
Hi Stefan,

on another instance I run into the problem of the limited ipc 0mq file name length. The logjam services started up just fine, but the ipc socket was never created. This patch logs error messages in this case. E.g.:

```
LJE[12562] Could not bind to socket /home/logjam/releases/7a7ca99d33d9e2424ff85e4d8c2c8d6788ebe761/tmp/sockets/state-logjam-production-12562.ipc: File name too long (36)
```

In addition we should maybe just let the service die? I mean, if it starts and it's not working, it's no help. And if the log goes to some file instead of STDOUT, failing early might be noticed early by the user. What do you think?

Cheers & merry christmas,
plu
