### PR TITLE
Make the websocket url customizable

### DIFF
--- a/app/controllers/logjam/logjam_controller.rb
+++ b/app/controllers/logjam/logjam_controller.rb
@@ -558,8 +558,7 @@ module Logjam
           get_app_env
           redirect_on_empty_dataset and return
           @resources = Logjam::Resource.time_resources-%w(total_time gc_time)
-          ws_port = RUBY_PLATFORM =~ /darwin/ ? 9608 : 8080
-          @socket_url = "ws://#{request.host}:#{ws_port}/"
+          @socket_url = Logjam.websocket_url_generator.call(request)
           @key = params[:page].to_s
           @key = "all_pages" if @key.blank? || @key == "::"
           @key = @key.sub(/^::/,'').downcase

--- a/lib/logjam.rb
+++ b/lib/logjam.rb
@@ -59,6 +59,21 @@ module Logjam
     @@ignored_request_uri = uri
   end
 
+  @@websocket_url_generator = ->(request) {
+    if RUBY_PLATFORM =~ /darwin/
+      "ws://#{request.host}:9680/"
+    else
+      "ws://#{request.host}:8080/"
+    end
+  }
+  def self.websocket_url_generator
+    @@websocket_url_generator
+  end
+
+  def self.websocket_url_generator=(websocket_url_generator)
+    @@websocket_url_generator = websocket_url_generator
+  end
+
   @@devices = nil
   def self.devices
     @@devices


### PR DESCRIPTION
I don't know if it's the best solution but this should work for our case (described in https://github.com/skaes/logjam_core/issues/54). We could get it to work using Nginx to terminate the TLS, so we needed to use some other address entirely.

I think this change shouldn't affect the current behavior. By the way, any reason to use different ports in OSX than on Linux? Might simplify things.

What do you think?