### PR TITLE
allow multilines on specific tables

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -63,6 +63,15 @@ table {
       border-bottom: 1px solid $lighter-grey !important;
       text-align: left !important;
     }
+    td {
+      vertical-align: top;
+    }
+  }
+
+  &.allow-multilines {
+    td {
+      white-space: pre;
+    }
   }
 
 }

--- a/app/views/logjam/logjam/show.html.erb
+++ b/app/views/logjam/logjam/show.html.erb
@@ -186,7 +186,7 @@
     <div class="flex">
       <div class="item">
         <h2>Javascript Exceptions</h2>
-        <table>
+        <table class="allow-multilines">
           <% @js_exceptions.each.with_index do |e, i| -%>
             <% unless i == 0 -%>
               <tr><td colspan=2><hr /></td></tr>


### PR DESCRIPTION
This pull request allows multilines on tables with the `.allow-multiline` class.
Additionally I added a vertical align-top to *all* tables cells