### PR TITLE
Add URL based filter to exclude certain response codes from livestream

### DIFF
--- a/app/views/logjam/logjam/live_stream.html.erb
+++ b/app/views/logjam/logjam/live_stream.html.erb
@@ -50,7 +50,7 @@
     legend: (@resources.reverse+%w(requests/second)).map{|r| r.gsub(/_/,' ')},
     socket_url: @socket_url,
     socket_greeting: "#{@app}-#{@env},#{@key}",
-    app_env: "app=#{@app}&env=#{@env}",
+    app_env: "app=#{@app}&env=#{@env}&exclude_status=#{@exclude_status}",
     transparent_ico_path: asset_path("t.png")
   }
 %>


### PR DESCRIPTION
Added as a pure URL based filter since
- this is the minimum requirement we have for the monitoring view of the live stream on a raspberry pi
- frontend would be more than a simple on/off button like pause or warnings but contain options for different response codes which seems to be overwhelming at first.
Therefore I decided to go with a simple URL filter.
Since it's stored as an array it could be enhanced by using additional form elements easily.

Usage:
- add a URL parameter `exclude_response=xxx,yyy` to the URL to filter out according errors.

Example:
- http://localhost:3000/2017/05/09/live_stream?env=development&exclude_response=503
- http://localhost:3000/2017/05/09/live_stream?env=development&exclude_response=400,401,503

Ideas for improvement:
- we could think about excluding whole ranges by setting `4xx` or `400-410`, but that's not needed at the moment (from our side).