### PR TITLE
Make livestream URL configurable

### DIFF
--- a/app/controllers/logjam/logjam_controller.rb
+++ b/app/controllers/logjam/logjam_controller.rb
@@ -713,7 +713,7 @@ module Logjam
           redirect_on_empty_dataset and return
           @resources = (Logjam::Resource.time_resources-%w(total_time gc_time)) & @collected_resources
           ws_port = RUBY_PLATFORM =~ /darwin/ ? 9608 : 8080
-          @socket_url = "ws://#{request.host}:#{ws_port}/"
+          @socket_url = ENV['LIVESTREAM_URL'] || "ws://#{request.host}:#{ws_port}/"
           @key = params[:page].to_s
           @key = "all_pages" if @key.blank? || @key == "::"
           @key = @key.sub(/^::/,'').downcase


### PR DESCRIPTION
This makes the livestream url configurable.
Works on a Xingbox.

It think it would close https://github.com/skaes/logjam_core/issues/54