### PR TITLE
Pass exclude_response when redirecting

### DIFF
--- a/app/controllers/logjam/logjam_controller.rb
+++ b/app/controllers/logjam/logjam_controller.rb
@@ -873,6 +873,7 @@ module Logjam
           :page => params[:page].to_s.sub(/\A::/,''), :response => params[:response],
           :resource => params[:resource],
           :sort => params[:sort], :group => params[:group], :filter => params[:filter],
+          :exclude_response => params[:exclude_response],
           :offset => params[:offset], :error_type => params[:error_type],
           :scale => params[:scale],
           :grouping => params[:grouping], :grouping_function => params[:grouping_function]}, params)

--- a/app/views/logjam/logjam/live_stream.html.erb
+++ b/app/views/logjam/logjam/live_stream.html.erb
@@ -50,7 +50,7 @@
     legend: (@resources.reverse+%w(requests/second)).map{|r| r.gsub(/_/,' ')},
     socket_url: @socket_url,
     socket_greeting: "#{@app}-#{@env},#{@key}",
-    app_env: "app=#{@app}&env=#{@env}&exclude_status=#{@exclude_status}",
+    app_env: "app=#{@app}&env=#{@env}&exclude_response=#{@exclude_response}",
     transparent_ico_path: asset_path("t.png")
   }
 %>


### PR DESCRIPTION
This parameter was left out previously so it got dropped when redirecting especially for `/live_stream` without date.