### PR TITLE
Change the width of the action_auto_complete_url

### DIFF
--- a/app/assets/javascripts/logjam-header.js
+++ b/app/assets/javascripts/logjam-header.js
@@ -134,7 +134,7 @@ function initialize_header() {
   });*/
 
   $("#namespace-suggest").select2({
-    width: 300,
+    width: 'fit-content',
     minimumInputLength: 0,
     ajax: {
       url: action_auto_complete_url,


### PR DESCRIPTION
When I try to look for an action and the name is not shown completely and you have to hover over it and wait for it to show. This is a small annoyance that other colleagues mentioned as well.
<img width="1625" alt="Screenshot 2020-11-20 at 14 27 17" src="https://user-images.githubusercontent.com/45359108/101631136-2c377e00-3a24-11eb-88fd-e5b35c65a8fe.png">
<img width="1635" alt="Screenshot 2020-11-20 at 14 28 00" src="https://user-images.githubusercontent.com/45359108/101631154-3194c880-3a24-11eb-9757-19380276c0f9.png">

Was not tested locally, just a css change in the browser