### PR TITLE
Fix timeline for logged warnings

### DIFF
--- a/app/controllers/logjam/logjam_controller.rb
+++ b/app/controllers/logjam/logjam_controller.rb
@@ -246,7 +246,7 @@ module Logjam
           minutes = Minutes.new(@db, @resources, @page, totals.page_names, 2)
           @timeline = eselector.call(minutes)
           qopts.merge!(:limit => @page_size, :skip => offset)
-          if (restricted = params.include?(:starte_minute) || params.include?(:end_minute))
+          if (restricted = params.include?(:start_minute) || params.include?(:end_minute))
             qopts[:start_minute] = params[:start_minute].to_i
             qopts[:end_minute] = params[:end_minute].to_i
           end

--- a/app/controllers/logjam/logjam_controller.rb
+++ b/app/controllers/logjam/logjam_controller.rb
@@ -240,7 +240,7 @@ module Logjam
                               end
             @resources = %w(severity)
             qopts = { :severity => severity }
-            eselector = ->(minutes) { minutes.severity_above(severity.to_s) }
+            eselector = ->(minutes) { minutes.select_severity_equals(severity.to_s) }
           end
           totals = Totals.new(@db, @resources, @page.blank? ? 'all_pages' : @page)
           minutes = Minutes.new(@db, @resources, @page, totals.page_names, 2)

--- a/app/models/logjam/minutes.rb
+++ b/app/models/logjam/minutes.rb
@@ -75,10 +75,10 @@ module Logjam
       @severity ||= extract_sub_hash('severity')
     end
 
-    def severity_above(sev)
-      i = sev.to_i
-      severity.each_with_object(Hash.new(0)) do |(k,h),s|
-        h.each{|m,c| s[m] += c} if k.to_i >= i
+    def select_severity_equals(selected_severity)
+      selected_severity = selected_severity.to_i
+      severity.each_with_object(Hash.new(0)) do |(sev,minutes),filtered|
+        minutes.each{ |m,c| filtered[m] += c } if sev.to_i == selected_severity
       end
     end
 


### PR DESCRIPTION
Errors subpages (such as "Logged Warnings") should both only list requests
that exactly match the maximum severity level (which was already the case)
and display only those requests in the timeline aggregation.