### PR TITLE
fix default page parameter handling for API

### DIFF
--- a/app/controllers/logjam/logjam_controller.rb
+++ b/app/controllers/logjam/logjam_controller.rb
@@ -496,7 +496,8 @@ module Logjam
           end
         end
         format.json do
-          page = @page == 'all_pages' ? '::' : @page
+          all_pages = @page == 'all_pages' || @page.to_s.empty?
+          page = all_pages ? '::' : @page.to_s
           page.sub!(/\A::/,'')
           app = page == '' ? @app : "#{@app}::"
           target = "#{app}#{page}"


### PR DESCRIPTION
If no page parameter is specified (e.g. if it is nil or an empty string)
we should default to a value instead of returning a 500.
This picks the 'all_pages' behaviour as the default.

The original issue can be reproduced by navigating to any app, clicking
"callers" and then clicking on "API response".