### PR TITLE
fix timezone issues for DST

### DIFF
--- a/app/helpers/logjam/logjam_helper.rb
+++ b/app/helpers/logjam/logjam_helper.rb
@@ -758,7 +758,7 @@ module Logjam
       if @date.nil? || (@date == Date.today && !restricted)
         { relative: 300 }
       else
-        date = @date.in_time_zone(Time.now.zone)
+        date = @date.to_time.localtime
         start_time = date + params[:start_minute].to_i.minutes
         end_time = date + params[:end_minute].to_i.minutes
         { rangetype: :absolute, from: start_time.iso8601, to: end_time.iso8601 }


### PR DESCRIPTION
Using Time.now.zone returns "CEST" which is not valid
for in_time_zone as that expects a "Continent/City" string
used by the IANA.

This uses localtime, which drops the timezone name, but keeps the correct
UTC offset.

Another solution would be to explicitly set the timezone in Rails
via config.time_zone
https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html#method-c-new

But we would need to either set it ourselves or read it from somewhere, which
does not seem necessary in this case as the UTC offset should be enough.